### PR TITLE
Change class access modifiers from internal to public

### DIFF
--- a/Mini Fitness Tracker/Engine/FitnessAppEngine.cs
+++ b/Mini Fitness Tracker/Engine/FitnessAppEngine.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Mini_Fitness_Tracker.Engine
 {
-    internal class FitnessAppEngine
+    public class FitnessAppEngine
     {
     }
 }

--- a/Mini Fitness Tracker/Models/Exercise.cs
+++ b/Mini Fitness Tracker/Models/Exercise.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Mini_Fitness_Tracker.Models
 {
-    internal class Exercise
+    public class Exercise
     {
     }
 }

--- a/Mini Fitness Tracker/Models/ProgressTracker.cs
+++ b/Mini Fitness Tracker/Models/ProgressTracker.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Mini_Fitness_Tracker.Models
 {
-    internal class ProgressTracker
+    public class ProgressTracker
     {
     }
 }

--- a/Mini Fitness Tracker/Models/User.cs
+++ b/Mini Fitness Tracker/Models/User.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Mini_Fitness_Tracker.Models
 {
-    internal class User
+    public class User
     {
     }
 }

--- a/Mini Fitness Tracker/Models/WorkOutPlan.cs
+++ b/Mini Fitness Tracker/Models/WorkOutPlan.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Mini_Fitness_Tracker.Models
 {
-    internal class WorkOutPlan
+    public class WorkOutPlan
     {
     }
 }

--- a/Mini Fitness Tracker/Ui/ConsoleUI.cs
+++ b/Mini Fitness Tracker/Ui/ConsoleUI.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Mini_Fitness_Tracker.Ui
 {
-    internal class ConsoleUI
+    public class ConsoleUI
     {
     }
 }

--- a/Mini Fitness Tracker/Utils/DataHandler.cs
+++ b/Mini Fitness Tracker/Utils/DataHandler.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Mini_Fitness_Tracker.Utils
 {
-    internal class DataHandler
+    public class DataHandler
     {
     }
 }


### PR DESCRIPTION
Updated access modifiers for multiple classes in the Mini_Fitness_Tracker application to public. This includes `FitnessAppEngine`, `Exercise`, `ProgressTracker`, `User`, `WorkOutPlan`, `ConsoleUI`, and `DataHandler`, allowing access from other assemblies for broader usage and integration.