### PR TITLE
Change FitnessAppEngine class to public

### DIFF
--- a/Mini Fitness Tracker/Engine/FitnessAppEngine.cs
+++ b/Mini Fitness Tracker/Engine/FitnessAppEngine.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Mini_Fitness_Tracker.Engine
 {
-    internal class FitnessAppEngine
+    public class FitnessAppEngine
     {
     }
 }


### PR DESCRIPTION
Updated the `FitnessAppEngine` class visibility from `internal` to `public`. This change allows the class to be accessed from other assemblies, enabling broader usage of its functionality within the application and by external applications.